### PR TITLE
Add `=destroy` hook for `Sound` and improve error management

### DIFF
--- a/src/slappy.nim
+++ b/src/slappy.nim
@@ -452,7 +452,7 @@ proc newSound*(filePath: string): Sound =
     sound = Sound()
   discard alGetError() # Clear error code
   alGenBuffers(1, addr sound.id)
-  if alGetError() != AL_NO_ERROR: fail "Couldn't create a sound's buffer ID."
+  sound.cleanupOnError("Couldn't create a sound's buffer ID.")
 
   proc format(bits, channels: SomeInteger): ALenum =
     if channels == 1:

--- a/src/slappy.nim
+++ b/src/slappy.nim
@@ -5,7 +5,7 @@ import
 
 type
   Listener* = object
-  Sound* = ref object
+  Sound* = object
     id: ALuint
   Source* = ref object
     id: ALuint
@@ -23,6 +23,13 @@ type
     freq: int
     queuedBuffers: seq[ALuint]
   SlappyError* = object of IOError
+
+proc cleanup(sound: var Sound) =
+  alDeleteBuffers(1, addr sound.id)
+  sound.id = 0
+
+proc `=destroy`(sound: var Sound) =
+  sound.cleanup()
 
 var
   listener* = Listener()
@@ -318,6 +325,12 @@ proc slappyTick*() =
       alDeleteSources(1, addr source.id)
     inc i
 
+proc cleanupOnError(sound: var Sound; msg: string) =
+  let hasError = alGetError() != AL_NO_ERROR
+  if not hasError: return
+  sound.cleanup()
+  fail(msg)
+
 proc listCaptureDevices*(): seq[string] =
   ## Returns a list of available audio capture device names.
   when defined(emscripten):
@@ -414,8 +427,11 @@ proc bits*(mic: Microphone): int {.inline.} =
 
 proc toSound*(mic: Microphone, data: seq[uint8]): Sound =
   ## Creates a playable Sound from captured PCM data.
-  let sound = Sound()
+  var
+    sound = Sound()
+  discard alGetError() # Clear error code
   alGenBuffers(1, addr sound.id)
+  sound.cleanupOnError("Couldn't create a buffer ID for a Microphone's sound data.")
   alBufferData(
     sound.id,
     mic.captureFormat,
@@ -423,17 +439,20 @@ proc toSound*(mic: Microphone, data: seq[uint8]): Sound =
     ALsizei(data.len),
     ALsizei(mic.captureFreq)
   )
+  sound.cleanupOnError("Couldn't convert a Microphone into a sound's buffer data.")
   return sound
 
 proc newSound*(): Sound =
-  ## Allocates an empty sound handle.
-  result.new()
+  ## Returns an empty sound handle.
+  Sound()
 
 proc newSound*(filePath: string): Sound =
   ## Loads a sound buffer from wav, slappy, or ogg files.
   var
     sound = Sound()
+  discard alGetError() # Clear error code
   alGenBuffers(1, addr sound.id)
+  if alGetError() != AL_NO_ERROR: fail "Couldn't create a sound's buffer ID."
 
   proc format(bits, channels: SomeInteger): ALenum =
     if channels == 1:
@@ -442,25 +461,16 @@ proc newSound*(filePath: string): Sound =
       elif bits == 8:
         result = AL_FORMAT_MONO8
       else:
-        raise newException(
-          SlappyError,
-          &"Got {bits} bits, only 8 or 16 bits per sample are supported"
-        )
+        fail &"Got {bits} bits, only 8 or 16 bits per sample are supported"
     elif channels == 2:
       if bits == 16:
         result = AL_FORMAT_STEREO16
       elif bits == 8:
         result = AL_FORMAT_STEREO8
       else:
-        raise newException(
-          SlappyError,
-          &"Got {bits} bits, only 8 or 16 bits per sample are supported"
-        )
+        fail &"Got {bits} bits, only 8 or 16 bits per sample are supported"
     else:
-      raise newException(
-        SlappyError,
-        &"Got {channels} channels, only 1 or 2 channel sounds supported"
-      )
+      fail &"Got {channels} channels, only 1 or 2 channel sounds supported"
 
   var wav: WavFile
   if filePath.endswith(".wav"):
@@ -470,10 +480,7 @@ proc newSound*(filePath: string): Sound =
   elif filePath.endswith(".ogg"):
     wav = loadVorbis(filePath)
   else:
-    raise newException(
-      SlappyError,
-      "File format not supported."
-    )
+    fail "File format not supported."
 
   alBufferData(
     sound.id,
@@ -482,6 +489,7 @@ proc newSound*(filePath: string): Sound =
     ALsizei wav.size,
     ALsizei wav.freq
   )
+  sound.cleanupOnError("Couldn't load a sound's buffer data.")
 
   return sound
 

--- a/src/slappy.nim
+++ b/src/slappy.nim
@@ -556,10 +556,7 @@ proc alFormat(channels, bits: int): ALenum =
   elif channels == 2:
     if bits == 16: return AL_FORMAT_STEREO16
     elif bits == 8: return AL_FORMAT_STEREO8
-  raise newException(
-    SlappyError,
-    &"Unsupported format: {channels} channels, {bits} bits."
-  )
+  fail &"Unsupported format: {channels} channels, {bits} bits."
 
 proc newStreamingSource*(
   frequency: int = 24000,

--- a/src/slappy.nim
+++ b/src/slappy.nim
@@ -5,7 +5,7 @@ import
 
 type
   Listener* = object
-  Sound* = object
+  Sound* = ref object
     id: ALuint
   Source* = ref object
     id: ALuint
@@ -24,11 +24,14 @@ type
     queuedBuffers: seq[ALuint]
   SlappyError* = object of IOError
 
-proc cleanup(sound: var Sound) =
+proc cleanup(sound: var typeof(Sound()[])) =
   alDeleteBuffers(1, addr sound.id)
   sound.id = 0
 
-proc `=destroy`(sound: var Sound) =
+template cleanup(sound: var Sound) =
+  sound[].cleanup()
+
+proc `=destroy`(sound: var typeof(Sound()[])) =
   sound.cleanup()
 
 var
@@ -444,12 +447,12 @@ proc toSound*(mic: Microphone, data: seq[uint8]): Sound =
 
 proc newSound*(): Sound =
   ## Returns an empty sound handle.
-  Sound()
+  new Sound
 
 proc newSound*(filePath: string): Sound =
   ## Loads a sound buffer from wav, slappy, or ogg files.
   var
-    sound = Sound()
+    sound = newSound()
   discard alGetError() # Clear error code
   alGenBuffers(1, addr sound.id)
   sound.cleanupOnError("Couldn't create a sound's buffer ID.")

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,4 +1,7 @@
-import math, os, slappy, vmath, slappy/wav, slappy/slappyformat
+import
+  std/[importutils],
+  math, os, vmath,
+  slappy, slappy/wav, slappy/slappyformat
 
 slappyInit()
 
@@ -28,6 +31,19 @@ block:
   echo "duration ", sound.duration
   discard sound.play()
   sleep(1000)
+
+block:
+  privateAccess(Sound)
+  echo "creating, duplicating and destroying wav file"
+  var sound = newSound()
+  let before = sound.id
+  sound = newSound("tests/data/xylophone-sweep.wav")
+  let afterOverwrite = sound.id
+  `=destroy`(sound[])
+  let afterDestroy = sound.id
+  doAssert before != afterOverwrite, "Sound.id must not be the same after overwriting an existing sound"
+  doAssert afterDestroy == 0, "Sound.id must be 0 after destroying an existing sound"
+  doAssert before == afterDestroy, "Sound.id must be reverted to its default value after destroying an existing sound"
 
 block:
   # playing sound in 3d

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,7 +1,7 @@
 import
   std/[importutils],
   math, os, vmath,
-  slappy, slappy/wav, slappy/slappyformat
+  slappy, slappy/wav, slappy/slappyformat, openal
 
 slappyInit()
 
@@ -34,7 +34,7 @@ block:
 
 block:
   privateAccess(Sound)
-  echo "creating, duplicating and destroying wav file"
+  echo "creating, duplicating and destroying a .wav file"
   var sound = newSound()
   let before = sound.id
   sound = newSound("tests/data/xylophone-sweep.wav")
@@ -44,6 +44,20 @@ block:
   doAssert before != afterOverwrite, "Sound.id must not be the same after overwriting an existing sound"
   doAssert afterDestroy == 0, "Sound.id must be 0 after destroying an existing sound"
   doAssert before == afterDestroy, "Sound.id must be reverted to its default value after destroying an existing sound"
+
+block:
+  privateAccess(Sound)
+  echo "duplicating and destroying a `Sound` object"
+  var
+    b: Sound
+    tmpId: ALuint
+  block:
+    var a = newSound("tests/data/xylophone-sweep.wav")
+    b = a
+    tmpId = a.id
+    # a goes out of scope
+  doAssert b.id != 0, "Sound.id for `b` must be valid atfer `a` goes out of scope"
+  doAssert b.id == tmpId, "Sound.id for `b` must be the id created by `a`"
 
 block:
   # playing sound in 3d


### PR DESCRIPTION
- Add `=destroy` hook to `Sound`
- Call `alDeleteBuffers` for `Sound` objects when they are destroyed.
- Add error checks on `Sound` object creation
- Change several exceptions to use the already existing `fail` helper template

References:
- https://www.openal.org/documentation/OpenAL_Programmers_Guide.pdf
- https://nim-lang.org/docs/destructors.html#lifetimeminustracking-hooks-nimeqdestroy-hook