### PR TITLE
Add `WavFile.toMono` and `newSound.forceMono`

### DIFF
--- a/src/slappy.nim
+++ b/src/slappy.nim
@@ -429,8 +429,9 @@ proc newSound*(): Sound =
   ## Allocates an empty sound handle.
   result.new()
 
-proc newSound*(filePath: string): Sound =
+proc newSound*(filePath: string; forceMono: bool = true): Sound =
   ## Loads a sound buffer from wav, slappy, or ogg files.
+  ## Files must be loaded as mono to use spatial sound features (default: true).
   var
     sound = Sound()
   alGenBuffers(1, addr sound.id)
@@ -474,6 +475,8 @@ proc newSound*(filePath: string): Sound =
       SlappyError,
       "File format not supported."
     )
+  if forceMono:
+    wav.toMono()
 
   alBufferData(
     sound.id,

--- a/src/slappy/wav.nim
+++ b/src/slappy/wav.nim
@@ -58,3 +58,22 @@ proc loadWav*(filePath: string): WavFile =
   result.freq = sampleRate.int64
   result.bits = bitsPerSample.int64
   result.data = cast[seq[uint8]](data)
+
+func stereoToMono[T: uint8 | int16](data: openArray[uint8]): seq[uint8] =
+  let samples = cast[ptr UncheckedArray[T]](unsafeAddr data[0])
+  let sampleCount = data.len div sizeof(T)
+  var monoData = newSeq[T](sampleCount div 2)
+  for i in 0 ..< monoData.len:
+    monoData[i] = T((int32(samples[i * 2]) + int32(samples[i * 2 + 1])) div 2)
+  result = newSeq[uint8](monoData.len * sizeof(T))
+  copyMem(addr result[0], addr monoData[0], result.len)
+
+func toMono*(wav: var WavFile): var WavFile {.discardable.}=
+  if wav.channels == 1: return
+  case wav.bits
+  of 8: wav.data = stereoToMono[uint8](wav.data)
+  of 16: wav.data = stereoToMono[int16](wav.data)
+  else: discard
+  wav.channels = 1
+  wav.size = wav.data.len
+  return wav

--- a/src/slappy/wav.nim
+++ b/src/slappy/wav.nim
@@ -59,16 +59,16 @@ proc loadWav*(filePath: string): WavFile =
   result.bits = bitsPerSample.int64
   result.data = cast[seq[uint8]](data)
 
-func stereoToMono[T: uint8 | int16](data: openArray[uint8]): seq[uint8] =
+proc stereoToMono[T: uint8 | int16](data: openArray[uint8]): seq[uint8] =
   let samples = cast[ptr UncheckedArray[T]](unsafeAddr data[0])
   let sampleCount = data.len div sizeof(T)
-  var monoData = newSeq[T](sampleCount div 2)
-  for i in 0 ..< monoData.len:
-    monoData[i] = T((int32(samples[i * 2]) + int32(samples[i * 2 + 1])) div 2)
-  result = newSeq[uint8](monoData.len * sizeof(T))
-  copyMem(addr result[0], addr monoData[0], result.len)
+  let monoSamples = sampleCount div 2
+  result = newSeq[uint8](monoSamples * sizeof(T))
+  let outSamples = cast[ptr UncheckedArray[T]](unsafeAddr result[0])
+  for i in 0 ..< monoSamples:
+    outSamples[i] = T((int32(samples[i * 2]) + int32(samples[i * 2 + 1])) div 2)
 
-func toMono*(wav: var WavFile): var WavFile {.discardable.}=
+proc toMono*(wav: var WavFile): var WavFile {.discardable.}=
   if wav.channels == 1: return
   case wav.bits
   of 8: wav.data = stereoToMono[uint8](wav.data)


### PR DESCRIPTION
Used for converting sound file data into mono/spatial on load.
Changes default behavior. All sounds now load as `mono`/`spatial` by default, unless specified otherwise.