### PR TITLE
[codex] migrate CI to Nimby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,25 @@
 name: Github Actions
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: jiro4989/setup-nim-action@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-    # Can't test without GUI, just compile.
-    - run: sudo apt-get install libopenal-dev
-    - run: nimble install -y
-    - run: nimble c tests/test.nim
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim r tests/tests.nim

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,24 +3,28 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+permissions:
+  contents: write
 env:
-  nim-version: 'stable'
   nim-src: src/${{ github.event.repository.name }}.nim
   deploy-dir: .gh-pages
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jiro4989/setup-nim-action@v1
-        with:
-          nim-version: ${{ env.nim-version }}
-      - run: nimble install -Y
-      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install -g "${{ github.event.repository.name }}/${{ github.event.repository.name }}.nimble"
+      - run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
       - name: Deploy documents
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.deploy-dir }}

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,0 +1,3 @@
+import test_midi
+
+echo "all tests pass"


### PR DESCRIPTION
## What changed

- Migrated build CI to `treeform/setup-nim-action@v6` with Nimby dependency installation from the workspace parent.
- Standardized CI to run `nim r tests/tests.nim` across Ubuntu, macOS, and Windows.
- Migrated docs CI to setup-nim v6, Nimby install, `workflow_dispatch`, and the required `nim doc` command.
- Added `tests/tests.nim` as a headless CI entrypoint for the MIDI test, leaving the audio playback test as manual.

## Validation

- `cd ..; nimby install -g slappy/slappy.nimble`
- `nim r tests/tests.nim`
- `nim doc --index:on --project --git.url:https://github.com/treeform/slappy --git.commit:master --out:.gh-pages src/slappy.nim`